### PR TITLE
Add foreman to Gemfile, simplify bin/dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Process manager for Procfile-based applications
+  gem "foreman"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
+    foreman (0.90.0)
+      thor (~> 1.4)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -409,6 +411,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  foreman
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
@@ -471,6 +474,7 @@ CHECKSUMS
   ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  foreman (0.90.0) sha256=ff675e2d47b607ac58714a6d4ac3e1ee8f06f41d8db084531c31961e2c3f117c
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5

--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,3 @@
 #!/usr/bin/env sh
 
-GEM_BIN="$(ruby -e 'puts Gem.user_dir')/bin"
-export PATH="$GEM_BIN:$PATH"
-
-if ! command -v foreman >/dev/null 2>&1; then
-  echo "Installing foreman..."
-  gem install foreman --user-install --no-document
-fi
-
-exec foreman start -f Procfile.dev "$@"
+exec bundle exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Foreman belongs in the bundle, not installed as a loose system gem with PATH hacks. bin/dev is now just `bundle exec foreman start`.